### PR TITLE
Add partial support of others OSes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,5 @@
 /output/main/
 /TS Screens/
 /output/
+venv
+*.pyc

--- a/AutoAFK.py
+++ b/AutoAFK.py
@@ -10,7 +10,7 @@ import requests
 
 currenttime = datetime.now()
 currenttimeutc = datetime.now(timezone.utc)
-cwd = (os.path.dirname(__file__) + '\\') # We prefix all file calls with cwd so we can call from other directories (I.E via batch or cron)
+cwd = os.path.dirname(__file__) # We prefix all file calls with cwd so we can call from other directories (I.E via batch or cron)
 config = configparser.ConfigParser()
 customtkinter.set_appearance_mode("dark")  # Modes: system (default), light, dark
 customtkinter.set_default_color_theme("green")  # Themes: blue (default), dark-blue, green
@@ -27,9 +27,9 @@ args = vars(parser.parse_args())
 
 global settings
 if args['config']:
-    settings = cwd + (args['config'])
+    settings = os.path.join(cwd, args['config'])
 else:
-    settings = cwd + 'settings.ini'
+    settings = os.path.join(cwd, 'settings.ini')
 config.read(settings)
 
 repo_releases = requests.get('https://api.github.com/repos/Fortigate/AutoAFK/releases/latest')
@@ -50,7 +50,7 @@ class App(customtkinter.CTk):
         # configure window
         self.title("AutoAFK " + version)
         self.geometry(f"{800}x{600}")
-        self.wm_iconbitmap(cwd + 'img\\auto.ico')
+        self.wm_iconbitmap(os.path.join(cwd, 'img', 'auto.ico'))
 
         # configure grid layout (4x4)
         self.grid_rowconfigure((0, 1, 2), weight=0)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,5 @@
+customtkinter==5.2.1
+numpy==1.26.2
+pure_python_adb==0.3.0.dev0
+PyScreeze==0.1.30
+Requests==2.31.0

--- a/tools.py
+++ b/tools.py
@@ -10,7 +10,7 @@ from numpy import asarray
 # Configs/settings
 config = configparser.ConfigParser()
 config.read(settings) # load settings
-cwd = (os.path.dirname(__file__) + '\\') # variable for current directory of AutoAFK.exe
+cwd = os.path.dirname(__file__) # variable for current directory of AutoAFK.exe
 os.system('color')  # So colourful text works
 connected = False
 connect_counter = 1
@@ -81,7 +81,7 @@ def configureADB():
     global adb_device
     global adb_devices
     config.read(settings)  # to load any new values (ie port changed and saved) into memory
-    adbpath = (os.path.dirname(__file__) + '\\adb.exe') # Locate adb.exe in working directory
+    adbpath = os.path.join(cwd, 'adb.exe') # Locate adb.exe in working directory
     Popen([adbpath, "kill-server"], stdout=PIPE).communicate()[0] # Restart the ADB server
     wait(2)
     adb_devices = Popen([adbpath, "devices"], stdout=PIPE).communicate()[0] # Run 'adb.exe devices' and pipe output to string
@@ -196,7 +196,7 @@ def connect_device():
 # Takes a screenshot and saves it locally
 def take_screenshot(device):
     image = device.screencap()
-    with open(cwd + 'screen.bin', 'wb') as f:
+    with open(os.path.join(cwd, 'screen.bin'), 'wb') as f:
         f.write(image)
 
 def save_screenshot(name):
@@ -223,8 +223,8 @@ def swipe(x1, y1, x2, y2, duration=100, seconds=1):
 def isVisible(image, confidence=0.9, seconds=1, retry=1, click=False):
     counter = 0
     take_screenshot(device)
-    screenshot = Image.open(cwd + 'screen.bin')
-    search = Image.open(cwd + 'img\\' + image + '.png')
+    screenshot = Image.open(os.path.join(cwd, 'screen.bin'))
+    search = Image.open(os.path.join(cwd, 'img', image + '.png'))
     res = locate(search, screenshot, grayscale=False, confidence=confidence)
 
     if res == None and retry != 1:
@@ -264,14 +264,14 @@ def clickXY(x,y, seconds=1):
 def click(image, confidence=0.9, seconds=1, retry=1, suppress=False, grayscale=False):
     counter = 0
     take_screenshot(device)
-    screenshot = Image.open(cwd + 'screen.bin')
-    search = Image.open(cwd + 'img\\' + image + '.png')
+    screenshot = Image.open(os.path.join(cwd, 'screen.bin'))
+    search = Image.open(os.path.join(cwd, 'img', image + '.png'))
     result = locate(search, screenshot, grayscale=grayscale, confidence=confidence)
 
     if result == None and retry != 1:
         while counter < retry:
             take_screenshot(device)
-            screenshot = Image.open(cwd + 'screen.bin')
+            screenshot = Image.open(os.path.join(cwd, 'screen.bin'))
             result = locate(search, screenshot, grayscale=grayscale, confidence=confidence)
             if result != None:
                 x, y, w, h = result
@@ -302,8 +302,8 @@ def click(image, confidence=0.9, seconds=1, retry=1, suppress=False, grayscale=F
 # Seconds is how long to pause after finding the image
 def clickMultipleChoice(image, choice, confidence=0.9, seconds=1):
     take_screenshot(device)
-    screenshot = Image.open(cwd + 'screen.bin')
-    search = Image.open(cwd + 'img\\' + image + '.png')
+    screenshot = Image.open(os.path.join(cwd, 'screen.bin'))
+    search = Image.open(os.path.join(cwd, 'img', image + '.png'))
     results = list(locateAll(search, screenshot, grayscale=False, confidence=confidence))
     if len(results) == 0:
         printError('clickMultipleChoice error, image:' + str(image) + ' not found')
@@ -323,8 +323,8 @@ def clickMultipleChoice(image, choice, confidence=0.9, seconds=1):
 
 def returnMultiple(image, confidence=0.9, seconds=1):
     take_screenshot(device)
-    screenshot = Image.open(cwd + 'screen.bin')
-    search = Image.open(cwd + 'img\\' + image + '.png')
+    screenshot = Image.open(os.path.join(cwd, 'screen.bin'))
+    search = Image.open(os.path.join(cwd, 'img', image + '.png'))
     results = list(locateAll(search, screenshot, grayscale=False, confidence=confidence))
     return results
 
@@ -332,7 +332,7 @@ def returnMultiple(image, confidence=0.9, seconds=1):
 # C Variable is array from 0 to 2 for RGB value
 def pixelCheck(x,y,c,seconds=1):
     take_screenshot(device)
-    screenshot = asarray(Image.open(cwd + 'screen.bin')) # Convert PIL Image to NumPy Array for tuples
+    screenshot = asarray(Image.open(os.path.join(cwd, 'screen.bin'))) # Convert PIL Image to NumPy Array for tuples
     wait(seconds)
     return screenshot[y, x, c]
 
@@ -342,9 +342,9 @@ def confirmLocation(location, change=True, bool=False):
     detected = ''
     locations = {'campaign_selected': 'campaign', 'darkforest_selected': 'darkforest', 'ranhorn_selected': 'ranhorn'}
     take_screenshot(device)
-    screenshot = Image.open(cwd + 'screen.bin')
+    screenshot = Image.open(os.path.join(cwd, 'screen.bin'))
     for location_button, string in locations.items():
-        search = Image.open(cwd + 'img\\buttons\\' + location_button + '.png')
+        search = Image.open(os.path.join(cwd, 'img', 'buttons', location_button + '.png'))
         res = locate(search, screenshot, grayscale=False)
         if res != None:
             detected = string
@@ -353,7 +353,7 @@ def confirmLocation(location, change=True, bool=False):
     if detected == location and bool is True:
         return True
     elif detected != location and change is True and bool is False:
-        click('buttons\\' + location + '_unselected')
+        click(os.path.join('buttons', location + '_unselected'))
     elif detected != location and bool is True:
         return False
 

--- a/tools.py
+++ b/tools.py
@@ -6,6 +6,8 @@ from subprocess import check_output, Popen, PIPE
 import time, socket, os, configparser, sys, tools
 from PIL import Image
 from numpy import asarray
+from shutil import which
+from platform import system
 
 # Configs/settings
 config = configparser.ConfigParser()
@@ -82,6 +84,8 @@ def configureADB():
     global adb_devices
     config.read(settings)  # to load any new values (ie port changed and saved) into memory
     adbpath = os.path.join(cwd, 'adb.exe') # Locate adb.exe in working directory
+    if system() != 'Windows' or not os.path.exists(adbpath):
+        adbpath = which('adb') # If we're not on Windows or can't find adb.exe in the working directory we try and find it in the PATH
     Popen([adbpath, "kill-server"], stdout=PIPE).communicate()[0] # Restart the ADB server
     wait(2)
     adb_devices = Popen([adbpath, "devices"], stdout=PIPE).communicate()[0] # Run 'adb.exe devices' and pipe output to string


### PR DESCRIPTION
Hello,

I fixed a few things to make AutoAFK compatible with others systems. Basically, the main issue when running AutoAFK is that it used anti slash for paths instead of slash. Modern Windows is compatible with slashes, but just in case, I've used Python's API to join paths. 
Instead of using adb.exe on others OSes, it now uses the adb available in the PATH. 
Also, I've added a requirements.txt file for an easy installation with pip.
And I gitignored the path usually used for venv, and also for compiled files. 

Now there is also another thing I noticed, that I might fix in another PR:
- The listing of the ADB devices is not robust at all. It doesn't support any kind of device other than emulator. 

Thank you.